### PR TITLE
chore: use latestRelease and previousRelease instead of lastStable and latestRelease

### DIFF
--- a/scripts/comment-on-issues.mjs
+++ b/scripts/comment-on-issues.mjs
@@ -3,7 +3,7 @@ import {
   commentOnIssue,
   commentOnPullRequest,
   getIssuesClosedByPullRequests,
-  prsMergedSinceStable,
+  prsMergedSinceLast,
 } from "./octokit.mjs";
 
 invariant(process.env.GITHUB_TOKEN, "GITHUB_TOKEN is required");
@@ -12,13 +12,15 @@ invariant(process.env.GITHUB_REPOSITORY, "GITHUB_REPOSITORY is required");
 const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
 
 async function commentOnIssuesAndPrsAboutRelease() {
-  let { latestRelease, pullRequests } = await prsMergedSinceStable({
+  let { latestRelease, pullRequests } = await prsMergedSinceLast({
     owner,
     repo,
   });
 
   let suffix = pullRequests.length === 1 ? "" : "s";
-  console.log(`Found ${pullRequests.length} PR${suffix} merged since stable`);
+  console.log(
+    `Found ${pullRequests.length} PR${suffix} merged since last release`
+  );
 
   for (let pr of pullRequests) {
     console.log(`commenting on pr #${pr.number}`);

--- a/scripts/octokit.mjs
+++ b/scripts/octokit.mjs
@@ -14,7 +14,7 @@ let gql = String.raw;
 const Octokit = RestOctokit.plugin(paginateRest);
 const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
 
-export async function prsMergedSinceStable({ owner, repo }) {
+export async function prsMergedSinceLast({ owner, repo }) {
   let releases = await octokit.paginate(octokit.rest.repos.listReleases, {
     owner,
     repo,
@@ -25,18 +25,13 @@ export async function prsMergedSinceStable({ owner, repo }) {
     return new Date(b.published_at) - new Date(a.published_at);
   });
 
-  // we sorted, so we can safely assume the first one we find is the latest stable
-  let lastStableIndex = sorted.findIndex((release) => {
-    return release.prerelease === false && release.draft === false;
-  });
-
-  let lastStable = sorted.at(lastStableIndex);
-  invariant(lastStable, "Could not find last stable release");
-
   let latestRelease = sorted.at(0);
   invariant(latestRelease, "Could not find latest release");
 
-  let startDate = new Date(lastStable.created_at);
+  let previousRelease = sorted.at(1);
+  invariant(previousRelease, "Could not find previous release");
+
+  let startDate = new Date(previousRelease.created_at);
   let endDate = new Date(latestRelease.created_at);
 
   const prs = await octokit.paginate(octokit.pulls.list, {


### PR DESCRIPTION
Signed-off-by: Logan McAnsh <logan@mcan.sh>