### PR TITLE
ci: use "$GITHUB_OUTPUT" instead of "::set-output"

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -81,7 +81,7 @@ jobs:
 
             git tag ${NEXT_VERSION}
 
-            echo ::set-output name=NEXT_VERSION::${NEXT_VERSION}
+            echo "NEXT_VERSION=${NEXT_VERSION}" >> $GITHUB_OUTPUT
           else
             echo "🛑 no changes since last nightly, skipping..."
           fi


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

Signed-off-by: Logan McAnsh <logan@mcan.sh>
